### PR TITLE
Issue #1065: Add the BasicDateField class into the date.tests.info file.

### DIFF
--- a/core/modules/date/tests/date.tests.info
+++ b/core/modules/date/tests/date.tests.info
@@ -1,3 +1,9 @@
+[DateFieldBasic]
+name = Date Field Basic
+description = Test basic date fields.
+group = Date
+file = date_field.test
+
 [DateUITestCase]
 name = Date Field UI
 description = Test creation of various date fields and widgets using Field UI


### PR DESCRIPTION
Hi @Graham-72 .

this PR should register the `BasicDateField` class.

thanks,
~Geoff